### PR TITLE
Make the highscores folder configurable via a latched cvar.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -153,6 +153,10 @@ g_motd_file::
     Specifies name of the file to load MOTD from. Should not include any
     extenstion part or slashes. Default value is empty (no MOTD set).
 
+g_highscore_path::
+    The directory that holds the highscore files. Useful when running multiple
+    OpenFFA servers from the same mod directory. Default is "highscores".
+
 g_bugs::
     Specifies whether some known Quake 2 gameplay bugs are enabled or not.
     Default value is 0.

--- a/g_local.h
+++ b/g_local.h
@@ -674,6 +674,7 @@ extern  cvar_t  *g_spawn_mode;
 extern  cvar_t  *g_team_chat;
 extern  cvar_t  *g_mute_chat;
 extern  cvar_t  *g_protection_time;
+extern  cvar_t  *g_highscore_path;
 extern  cvar_t  *dedicated;
 
 extern  cvar_t  *sv_gravity;

--- a/g_main.c
+++ b/g_main.c
@@ -60,6 +60,7 @@ cvar_t  *g_protection_time;
 cvar_t  *g_log_stats;
 cvar_t  *g_skins_file;
 cvar_t  *g_motd_file;
+cvar_t  *g_highscore_path;
 cvar_t  *dedicated;
 
 cvar_t  *sv_maxvelocity;
@@ -296,13 +297,13 @@ static void G_SaveScores(void)
         return;
     }
 
-    len = Q_concat(path, sizeof(path), game.dir, "/highscores", NULL);
+    len = Q_concat(path, sizeof(path), game.dir, "/", g_highscore_path->string, NULL);
     if (len >= sizeof(path)) {
         return;
     }
     os_mkdir(path);
 
-    len = Q_concat(path, sizeof(path), game.dir, "/highscores/",
+    len = Q_concat(path, sizeof(path), game.dir, "/", g_highscore_path->string, "/",
                    level.mapname, ".txt", NULL);
     if (len >= sizeof(path)) {
         return;
@@ -380,7 +381,7 @@ void G_LoadScores(void)
     load_file_t *f;
     int i;
 
-    f = G_LoadFile("highscores", level.mapname);
+    f = G_LoadFile(g_highscore_path->string, level.mapname);
     if (!f) {
         return;
     }
@@ -1198,6 +1199,7 @@ static void G_Init(void)
     g_protection_time = gi.cvar("g_protection_time", "0", 0);
     g_skins_file = gi.cvar("g_skins_file", "", CVAR_LATCH);
     g_motd_file = gi.cvar("g_motd_file", "", CVAR_LATCH);
+    g_highscore_path = gi.cvar("g_highscore_path", "highscores", CVAR_LATCH);
 
     run_pitch = gi.cvar("run_pitch", "0.002", 0);
     run_roll = gi.cvar("run_roll", "0.005", 0);


### PR DESCRIPTION
The highscore mechanism doesn't allow for multiple ports running from the same gamedir, they'll share a common `highscores` folder since it's hard coded. This allows for the folder to be set in a server config so each port can have its own.